### PR TITLE
Removed Arbitrum Row

### DIFF
--- a/src/pages/vrf/v2/introduction.mdx
+++ b/src/pages/vrf/v2/introduction.mdx
@@ -50,7 +50,6 @@ Depending on your use case, one method might be more suitable than another. Cons
 | More random values returned per single request. See the maximum random values per request for the [Subscription supported networks](/vrf/v2/subscription/supported-networks/#configurations). | Fewer random values returned per single request than the subscription method, due to higher overhead. See the maximum random values per request and gas overhead for the [Direct funding supported networks](/vrf/v2/direct-funding/supported-networks/#configurations). |
 | You don't have to estimate costs precisely for each request. Ensure that the subscription account has enough funds. | You must estimate transaction costs carefully for each request to ensure the consuming contract has enough funds to pay for the request. |
 | Requires a subscription account | No subscription account required |
-| Supported on Arbitrum | Not yet supported on Arbitrum |
 | VRF costs are billed to your subscription account. [Manage and monitor your balance](/vrf/v2/subscription/ui) | No refunds for overpayment after requests are completed |
 | Flexible funding method first introduced in VRF v2. [Compare the VRF v2 subscription method to VRF v1](/vrf/v2/subscription/migration-from-v1). | Similar funding method to VRF v1, with the benefit of receiving more random values per request than VRF v1. [Compare direct funding in VRF v2 and v1](/vrf/v2/direct-funding/migration-from-v1). |
 


### PR DESCRIPTION
We can remove this row from the table as Arbitrum is supported for both subscription and direct funding.